### PR TITLE
Add SuperSplat utility

### DIFF
--- a/README.md
+++ b/README.md
@@ -259,6 +259,7 @@ GPU, much faster than previous methods, while the generated instances can be dir
 - [3DGS Converter for editing 3DGS .ply files in Cloud Compare](https://github.com/francescofugazzi/3dgsconverter)
 - [Kapture (for bundler to colmap model conversion)](https://github.com/naver/kapture) 
 - [Kapture image cropper script and conversion instructions](https://gist.github.com/jo-chemla/258e6e40d3d6c2220b29518ff3c17c40)
+- [SuperSplat](https://playcanvas.com/super-splat) - open source browser-based tool to clean up and reorient .ply files
 
 ## Blog Posts
 


### PR DESCRIPTION
This PR adds the [SuperSplat](https://playcanvas.com/super-splat) tool to the Utilities section. See the GitHub repo for more details:

https://github.com/playcanvas/super-splat