### PR TITLE
Add PlayCanvas implementation to Game Engines section

### DIFF
--- a/README.md
+++ b/README.md
@@ -269,6 +269,7 @@ using the same training and test data.
 
 ### Game Engines 
 - [Unity Implementation](https://github.com/aras-p/UnityGaussianSplatting)
+- [PlayCanvas Implementation](https://github.com/playcanvas/engine/tree/main/extras/splat)
 
 ### Viewers
 - [WebGL Viewer 1](https://github.com/antimatter15/splat)


### PR DESCRIPTION
Added the PlayCanvas Engine runtime implementation of 3D Gaussian Splatting. This powers [SuperSplat](https://github.com/playcanvas/super-splat), the [Splat Viewer](https://github.com/playcanvas/model-viewer) along with any other 3DGS PlayCanvas application.