### PR TITLE
update OpenGL viewer description

### DIFF
--- a/README.md
+++ b/README.md
@@ -1205,7 +1205,7 @@ representation. This method uses the Radial Basis Function (RBF) neural network.
 - [WebRTC viewer](https://github.com/dylanebert/gaussian-viewer)
 - [iOS & Metal viewer](https://github.com/laanlabs/metal-splats)
 - [jupyter notebook](https://github.com/shumash/gaussian-splatting/blob/mshugrina/interactive/interactive.ipynb)
-- [python OpenGL viewer](https://github.com/limacv/GaussianSplattingViewer.git)
+- [PyOpenGL viewer (also with official CUDA backend)](https://github.com/limacv/GaussianSplattingViewer.git)
 - [PlayCanvas Viewer](https://github.com/playcanvas/model-viewer)
 - [gsplat.js](https://github.com/dylanebert/gsplat.js)
 


### PR DESCRIPTION
The PyOpenGL viewer https://github.com/limacv/GaussianSplattingViewer now supports the official cuda rasterizer. Which can be a useful tool for simple visualization & customize viewer with new functionality.