### PR TITLE
Change pointrix framework link to msplat

### DIFF
--- a/README.md
+++ b/README.md
@@ -2892,7 +2892,7 @@ The advancement of real-time 3D scene reconstruction and novel view synthesis ha
 - [Tutorial from the authors of 3DGS](https://3dgstutorial.github.io/)
 
 ### Framework
-- [Pointrix](https://github.com/pointrix-project/pointrix) - A differentiable point-based rendering library with a focus on gaussian splatting
+- [msplat](https://github.com/pointrix-project/msplat) - A modular differential gaussian rasterization library.
 - [GauStudio](https://github.com/GAP-LAB-CUHK-SZ/gaustudio) - Unified framework with different paper implementations
 
 ### Other


### PR DESCRIPTION
It seems they have refactored the pointrix project (old URL is broken) into msplat: https://github.com/pointrix-project/msplat