### PR TITLE
Parse arxiv PDF links

### DIFF
--- a/arxiv_integration.py
+++ b/arxiv_integration.py
@@ -26,8 +26,11 @@ class ArxivIntegration:
         
         # Extract ID from path
         path = parsed.path
-        if 'abs' in path:
+        if 'abs' in path or 'pdf' in path:
             arxiv_id = path.split('/')[-1]
+            # Remove .pdf extension if present
+            if arxiv_id.endswith('.pdf'):
+                arxiv_id = arxiv_id[:-4]
         else:
             # If it's already an ID format (YYMM.NNNNN)
             arxiv_id = path.strip('/')


### PR DESCRIPTION
Parse arxiv links in the pdf format, e.g. https://arxiv.org/pdf/2403.14530 or https://arxiv.org/pdf/2403.14530.pdf