### PR TITLE
Add Mkkellogg's viewer

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ Visit our comprehensive, searchable database of 3D Gaussian Splatting papers:
 - [Splat Viewer](https://github.com/antimatter15/splat)
 - [Gauzilla](https://github.com/BladeTransformerLLC/gauzilla)
 - [Interactive Viewer](https://github.com/kishimisu/Gaussian-Splatting-WebGL)
+- [GaussianSplats3D](https://github.com/mkkellogg/GaussianSplats3D)
 
 **WebGPU**
 - [EPFL Viewer](https://github.com/cvlab-epfl/gaussian-splatting-web)


### PR DESCRIPTION
# Description
Mkkellogg's viewer is a great open-source WebGL viewer that supports splats up to SH 2. I personally used it in a few projects already.

I strongly think it deserves to be on the list. Feel free to close this PR if you disagree.