### PR TITLE
Add ri3d pipeline

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ Visit our comprehensive, searchable database of 3D Gaussian Splatting papers:
 | [OpenSplat](https://github.com/pierotofy/OpenSplat)                         | C++/CPU/GPU | AGPL-3.0   | Cross-platform solution         |
 | [Grendel](https://github.com/nyu-systems/Grendel-GS)                        | Python/CUDA | Apache-2.0 | Distributed computing focus     |
 | [Warp 3DGS](https://github.com/guoriyue/3dgs-warp-scratch)                  | Warp/Python | AGPL-3.0   | Warp-based implementation       |
+| [RI3D](https://github.com/Asus-Monitor/ri3d-impl)                           | Python/CUDA | Unlicense  | Few-shot gaussian splatting pipeline |
 
 ### Frameworks
 


### PR DESCRIPTION
Hi, i want to add my implementation of the RI3D paper pipeline. RI3D is a fairly new but super cool paper enabling like good looking splats with only 3 photos. Sadly they don't release the implementation, so i had to write my own. Mine is not as good as theirs since i had to guess a lot of the time, but its getting better. i think it would be useful for people to know about it.  I have trouble running the yaml gui editor to add the paper there too, could someone do this for me? The paper is https://people.engr.tamu.edu/nimak/Papers/RI3D/index.html