### PR TITLE
Add vggt-factor-refinement (COLMAP-free pipeline for 3DGS)

### DIFF
--- a/README.md
+++ b/README.md
@@ -216,6 +216,7 @@ Visit our comprehensive, searchable database of 3D Gaussian Splatting papers:
 - [SpectacularAI](https://github.com/SpectacularAI/point-cloud-tools) - Conversion scripts for different 3DGS conventions
 - [GSOPs](https://github.com/david-rhodes/GSOPs) - GSOPs (Gaussian Splat Operators) for SideFX Houdini. Import, edit, and export models, or generate synthetic training data
 - [Point Cloud Editor](https://github.com/JohannesKrueger/pointcloudeditor) - Clean and edit pointclouds from that are in colmap sparse format in a browser to improve reconstruction results
+- [VGGT Factor Refinement](https://github.com/jashshah999/vggt-factor-refinement) - COLMAP-free reconstruction pipeline using VGGT + factor graph. One command from video to COLMAP-format output for 3DGS training. Works on 8GB+ GPUs.
 
 ### Tutorial
 - [Tutorial from the authors of 3DGS](https://3dgstutorial.github.io/)


### PR DESCRIPTION
Adds [vggt-factor-refinement](https://github.com/jashshah999/vggt-factor-refinement) to the Utilities section.

**What it does:** One-command pipeline from video to COLMAP sparse format, using VGGT (feed-forward pose estimation) + factor graph refinement instead of traditional COLMAP. Outputs sparse/0/ that works directly with train.py.

**Why it's useful for 3DGS users:**
- 10-100x faster than COLMAP
- Works on 8GB+ GPUs (auto chunk sizing)
- Handles 300+ frame sequences with loop closure
- Also exports nerfstudio transforms.json and .ply