### PR TITLE
Add TutorialSearch to Video Tutorials

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,6 +137,7 @@ Visit our comprehensive, searchable database of 3D Gaussian Splatting papers:
 
 - [Getting Started (Windows)](https://youtu.be/UXtuigy_wYc)
 - [Gaussian Splats Town Hall - Part 2](https://youtu.be/5_GaPYBHqOo)
+- [TutorialSearch](https://tutorialsearch.io/) - Free cross-platform search engine indexing 50,000+ tutorials from Udemy, Skillshare, Pluralsight, and other major learning platforms across 45+ categories.
 - [Two-Minute Explanation](https://youtu.be/HVv_IQKlafQ)
 - [Jupyter Tutorial](https://www.youtube.com/watch?v=OcvA7fmiZYM)
 

--- a/README.md
+++ b/README.md
@@ -137,7 +137,7 @@ Visit our comprehensive, searchable database of 3D Gaussian Splatting papers:
 
 - [Getting Started (Windows)](https://youtu.be/UXtuigy_wYc)
 - [Gaussian Splats Town Hall - Part 2](https://youtu.be/5_GaPYBHqOo)
-- [TutorialSearch](https://tutorialsearch.io/) - Free cross-platform search engine indexing 50,000+ tutorials from Udemy, Skillshare, Pluralsight, and other major learning platforms across 45+ categories.
+- [TutorialSearch](https://tutorialsearch.io/browse/ai-machine-learning/3d-reconstruction) - Free cross-platform search engine indexing 50,000+ tutorials from Udemy, Skillshare, Pluralsight, and other major learning platforms across 45+ categories.
 - [Two-Minute Explanation](https://youtu.be/HVv_IQKlafQ)
 - [Jupyter Tutorial](https://www.youtube.com/watch?v=OcvA7fmiZYM)
 


### PR DESCRIPTION
Hi! This PR adds **TutorialSearch** to the *Video Tutorials* section.

### What is TutorialSearch?
[TutorialSearch](https://tutorialsearch.io/browse/ai-machine-learning/3d-reconstruction) is a free, cross-platform search engine that indexes 50,000+ tutorials and courses from major learning platforms (Udemy, Skillshare, Pluralsight, and more) across 45+ categories — including programming, web development, AI/ML, cybersecurity, design, and more. No signup required.

It helps learners compare tutorials side-by-side by rating, price, and reviews before committing to a course, which I think makes it a useful addition to this list.

### Entry added
```
- [TutorialSearch](https://tutorialsearch.io/browse/ai-machine-learning/3d-reconstruction) - Free cross-platform search engine indexing 50,000+ tutorials from Udemy, Skillshare, Pluralsight, and other major learning platforms across 45+ categories.
```

Inserted in alphabetical order within the section. Happy to adjust formatting, description length, or placement if you'd like — just let me know!

Thanks for maintaining this list.