### PR TITLE
Add splatreg (splat-to-splat registration & merge) to Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,7 @@ Visit our comprehensive, searchable database of 3D Gaussian Splatting papers:
 - [gsbox Converter](https://github.com/gotoeasy/gsbox) - PLY SPLAT SPZ SPX conversion tool
 - [SplatTransform](https://github.com/playcanvas/splat-transform) - CLI tool for converting and editing splats
 - [GaussForge](https://github.com/3dgscloud/GaussForge) - C++/WASM-based conversion between PLY, SPZ, SPLAT, and KSPLAT.
+- [splatreg](https://github.com/Archerkattri/splatreg) - pip-installable splat registration: align & merge two 3DGS scans into one SE(3)/Sim(3) frame (recovers scale), CLI + pure-PyTorch API, no manual gizmo.
 
 ### Development Tools
 


### PR DESCRIPTION
Adds **splatreg** to Tools & Utilities → Data Processing.

What it is: a pip-installable library + CLI that registers native Gaussian splats — it finds the SE(3) or Sim(3) (+scale) transform aligning two 3DGS scans, then merges and dedupes them into one splat. `splatreg align a.ply b.ply -o aligned.ply` / `splatreg merge a.ply b.ply -o fused.ply` on standard 3DGS PLYs (gsplat / Nerfstudio-splatfacto / INRIA / SuperSplat).

Why it fits the list: merging overlapping captures is a long-standing gap in the toolchain (SuperSplat issues #111/#53/#413 ask for exactly this; SplatTransform merges only with manual transforms). splatreg automates it: global init (super-Fibonacci sweep / FPFH+RANSAC / GeoTransformer) + Levenberg–Marquardt over ICP + a closed-form-Jacobian Gaussian-SDF residual.

Validation is public and reproducible: 91.5% official 3DMatch recall (GeoTransformer-class), real-splat merge Chamfer 10.3→2.0 mm vs naive concat, ~17 ms fast registration; honest limitations documented (low-overlap ambiguity is flagged, not hidden).

- Repo: https://github.com/Archerkattri/splatreg
- Docs: https://archerkattri.github.io/splatreg/
- PyPI: https://pypi.org/project/splatreg/ (`pip install splatreg`)
- License: BSD-3-Clause

Disclosure: I'm the author.
