### PR TITLE
Add SplatMart marketplace to Tools & Utilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,7 @@ Visit our comprehensive, searchable database of 3D Gaussian Splatting papers:
 
 - [GSOPs for Houdini](https://github.com/david-rhodes/GSOPs) - Houdini integration tools
 - [camorph](https://github.com/Fraunhofer-IIS/camorph) - Camera parameter conversion
+- [SplatMart](https://www.splatmart.com) - Marketplace for buying and selling Gaussian splat scenes and assets (PLY/SOGS/SPZ)
 - [SuperSplat](https://github.com/playcanvas/supersplat) - Browser-based 3DGS editor
 
 ## Learning Resources


### PR DESCRIPTION
Adds SplatMart, a marketplace for buying and selling 3D Gaussian Splatting scenes and assets, to Tools & Utilities. Assets are delivered as PLY/SOGS/SPZ with an in-browser viewer for every listing.

Disclosure: I'm the founder. I kept the description neutral and matched the existing entry format. Since it's a marketplace rather than an open-source tool, I placed it under Development Tools next to SuperSplat — happy to move it to a dedicated Marketplaces subsection, or to adjust the wording or placement however fits the list best.