### PR TITLE
Add AURA — calibrated per-splat confidence + certified pruning

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,7 @@ Visit our comprehensive, searchable database of 3D Gaussian Splatting papers:
 - [SplatTransform](https://github.com/playcanvas/splat-transform) - CLI tool for converting and editing splats
 - [GaussForge](https://github.com/3dgscloud/GaussForge) - C++/WASM-based conversion between PLY, SPZ, SPLAT, and KSPLAT.
 - [splatreg](https://github.com/Archerkattri/splatreg) - pip-installable splat registration: align & merge two 3DGS scans into one SE(3)/Sim(3) frame (recovers scale), CLI + pure-PyTorch API, no manual gizmo.
+- [AURA](https://github.com/Archerkattri/aura) - Calibrated per-splat confidence for 3DGS assets: held-out reliability labels, isotonic calibration, and a distribution-free conformal pruning certificate with a certified LOD ladder; exports via glTF/OpenUSD/SPZ (pip install aura-splat).
 
 ### Development Tools
 


### PR DESCRIPTION
Adds [AURA](https://github.com/Archerkattri/aura) to Tools & Utilities (next to splatreg, same author): a pip-installable library (`aura-splat`) that attaches a calibrated, certified per-splat confidence to trained 3DGS assets — held-out multi-view reliability labels, isotonic calibration (ECE ~300-900x reduction on 4 real scenes), and a distribution-free split-conformal pruning certificate extended to a certified LOD ladder; ships the confidence via KHR_gaussian_splatting/OpenUSD/SPZ. MIT-licensed core, archived at doi:10.5281/zenodo.21500723.