### PR TITLE
Add Godot plugin (gdgs) to Game Engines

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,7 @@ Visit our comprehensive, searchable database of 3D Gaussian Splatting papers:
 - [Unreal Plugin (MLSLabsGaussianSplattingRenderer-UE)](https://github.com/mlslabs/MLSLabsGaussianSplattingRenderer-UE)
 - [Unreal Plugin (XScene-UEPlugin)](https://github.com/xverse-engine/XScene-UEPlugin)
 - [PlayCanvas Engine](https://github.com/playcanvas/engine)
+- [Godot Plugin (gdgs)](https://github.com/ReconWorldLab/godot-gaussian-splatting) - Real-time 3DGS rendering plugin for Godot 4.3+
 
 ### Web Viewers
 


### PR DESCRIPTION
Adds one entry to **Viewers & Game Engine Support → Game Engines**:

- [Godot Plugin (gdgs)](https://github.com/ReconWorldLab/godot-gaussian-splatting) - Real-time 3DGS rendering plugin for Godot 4.3+

The section currently lists Unity, Unreal and PlayCanvas, but no Godot plugin, so this fills a gap rather than duplicating an existing entry.

About the project (disclosure: I'm the author):

- MIT licensed, currently at v3.3.0
- Imports `.ply`, `.compressed.ply`, `.splat` and `.sog` into a shared resource
- Two rendering backends: a tile-based compute backend (Forward+) and a raster "sticker" backend that also runs on Mobile and GL Compatibility
- Optional static collision generation and relighting from scene lights

Only `README.md` is touched, per CONTRIBUTING.md's "Adding Other Resources" instructions.