### PR TITLE
Improve accuracy of PlayCanvas entries and add SOG blog post

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,14 +91,14 @@ Visit our comprehensive, searchable database of 3D Gaussian Splatting papers:
 - [A-Frame](https://github.com/quadjr/aframe-gaussian-splatting)
 - [splaTV](https://github.com/antimatter15/splaTV) - Viewer for 4D Gaussians, with a [live demo](http://antimatter15.com/splaTV/)
 - [WebRTC viewer](https://github.com/dylanebert/gaussian-viewer)
-- [PlayCanvas Model Viewer](https://github.com/playcanvas/model-viewer)
-- [SuperSplat Viewer](https://github.com/playcanvas/supersplat-viewer)
 
 **WebGPU**
 
 - [EPFL Viewer](https://github.com/cvlab-epfl/gaussian-splatting-web)
 - [WebGPU Splat](https://github.com/KeKsBoTer/web-splat)
 - [gaussian-splatting-webgpu](https://github.com/MarcusAndreasSvensson/gaussian-splatting-webgpu)
+- [SuperSplat Viewer](https://github.com/playcanvas/supersplat-viewer) - High-performance splat viewer
+- [PlayCanvas Model Viewer](https://github.com/playcanvas/model-viewer) - Viewer for glTF and 3DGS assets
 
 ### Desktop Viewers
 
@@ -133,7 +133,7 @@ Visit our comprehensive, searchable database of 3D Gaussian Splatting papers:
 - [Point Cloud Editor](https://github.com/JohannesKrueger/pointcloudeditor) - Web-based point cloud editing
 - [SPZ Converter](https://github.com/stytim/spz) - SPZ conversion tool
 - [gsbox Converter](https://github.com/gotoeasy/gsbox) - PLY SPLAT SPZ SPX conversion tool
-- [SplatTransform](https://github.com/playcanvas/splat-transform) - CLI tool for converting and editing splats
+- [SplatTransform](https://github.com/playcanvas/splat-transform) - CLI tool and Node/browser library for converting and editing splats, reads PLY, SOG, SPZ, SPLAT, KSPLAT and LCC/LCC2, writes PLY, SOG, SPZ, GLB, CSV, LOD and WebP
 - [GaussForge](https://github.com/3dgscloud/GaussForge) - C++/WASM-based conversion between PLY, SPZ, SPLAT, and KSPLAT
 - [SpectacularAI](https://github.com/SpectacularAI/point-cloud-tools) - Conversion scripts for different 3DGS conventions
 - [VGGT Factor Refinement](https://github.com/jashshah999/vggt-factor-refinement) - COLMAP-free pipeline using VGGT + factor graph, from video to COLMAP-format output
@@ -144,7 +144,7 @@ Visit our comprehensive, searchable database of 3D Gaussian Splatting papers:
 
 - [GSOPs for Houdini](https://github.com/cgnomads/GSOPs) - Houdini integration tools
 - [camorph](https://github.com/Fraunhofer-IIS/camorph) - Camera parameter conversion
-- [SuperSplat](https://github.com/playcanvas/supersplat) - Browser-based 3DGS editor
+- [SuperSplat](https://github.com/playcanvas/supersplat) - Free, open source browser-based 3DGS editor with one-click publishing
 
 ## Learning Resources
 
@@ -157,6 +157,7 @@ Visit our comprehensive, searchable database of 3D Gaussian Splatting papers:
 - [Making Gaussian Splats smaller](https://aras-p.info/blog/2023/09/13/Making-Gaussian-Splats-smaller/)
 - [Making Gaussian Splats more smaller](https://aras-p.info/blog/2023/09/27/Making-Gaussian-Splats-more-smaller/)
 - [Compressing Gaussian Splats](https://blog.playcanvas.com/compressing-gaussian-splats/)
+- [PlayCanvas Open Sources SOG](https://blog.playcanvas.com/playcanvas-open-sources-sog-format-for-gaussian-splatting/) - Spatially Ordered Gaussians, a super-compressed format based on WebP that is 15-20x smaller than PLY
 - [Implementation Details](https://github.com/kwea123/gaussian_splatting_notes) - Technical deep dive
 - [Mathematical Foundation](https://github.com/chiehwangs/3d-gaussian-theory) - Theory explanation
 - [Mathematical details of forward and backward passes](https://github.com/joeyan/gaussian_splatting/blob/main/MATH.md)


### PR DESCRIPTION
Four small accuracy improvements to the existing PlayCanvas entries, plus one new blog post. No new tools or projects are added.

### Web Viewers — move the two PlayCanvas viewers to WebGPU

Both were listed under **WebGL**. Both support WebGPU, so they now sit under **WebGPU**.

### SplatTransform — cover library use and formats

The entry read "CLI tool for converting and editing splats". It is also a platform-agnostic library that runs in Node and the browser, and it reads/writes a wider set of formats than the description implied. Since neighboring entries in Data Processing enumerate their formats (gsbox, GaussForge), I have matched that convention.

### SuperSplat — cover licensing and publishing

The entry read "Browser-based 3DGS editor", which omitted that it is free, MIT licensed, and can publish scenes directly.

### Blog Posts — add SOG open sourcing

[PlayCanvas Open Sources SOG](https://blog.playcanvas.com/playcanvas-open-sources-sog-format-for-gaussian-splatting/) (17 Sept 2025). SOG is a super-compressed, WebP-based container format, roughly 15–20x smaller than PLY, with a published spec at [developer.playcanvas.com/user-manual/gaussian-splatting/formats/sog/](https://developer.playcanvas.com/user-manual/gaussian-splatting/formats/sog/). Placed next to the existing compression posts.

---

**One suggestion, entirely up to you:** editors are currently split across two sections — Point Cloud Editor sits under *Data Processing* while SuperSplat sits under *Development Tools*. If an `Editors` subsection would be useful, I am happy to add one in a follow-up; I did not want to reorganize your taxonomy unasked.

Disclosure: I work on PlayCanvas. I have kept this to correcting and expanding entries that were already in the list, and I am glad to trim anything that reads as too much detail.

All touched links verified as returning HTTP 200.

