### PR TITLE
Add pure PyTorch 3DGS implementation by Chi-Blaze-B

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ Visit our comprehensive, searchable database of 3D Gaussian Splatting papers:
 | [360-gaussian-splatting](https://github.com/inuex35/360-gaussian-splatting) | Python | | Trains splats directly from 360° images |
 | [2D Gaussian Splatting](https://github.com/OutofAi/2D-Gaussian-Splatting) | Jupyter | MIT | Notebook walkthrough of 2D gaussian splatting |
 | [DGSO](https://github.com/An-u-rag/stylized-gaussian-splatting) | Python | MIT | Style transfer applied during gaussian optimization |
+| [3D-Gaussian-Splatting-Reconstruction](https://github.com/Chi-Blaze-B/3D-Gaussian-Splatting-Reconstruction) | Python | Apache-2.0 | Pure PyTorch implementation from video input — no CUDA compilation required, supports CPU/NVIDIA GPU backends, built-in pose estimator & GUI |
 
 ### Frameworks
 


### PR DESCRIPTION
This PR adds [3D-Gaussian-Splatting-Reconstruction](https://github.com/Chi-Blaze-B/3D-Gaussian-Splatting-Reconstruction), a pure PyTorch implementation of 3DGS from video input. No CUDA compilation required, supports CPU/NVIDIA GPU backends, with built-in pose estimator and GUI.